### PR TITLE
fix: update for cdk 0.16 API changes

### DIFF
--- a/rust/src/api/error.rs
+++ b/rust/src/api/error.rs
@@ -62,6 +62,12 @@ impl From<cdk::nuts::nut11::Error> for Error {
     }
 }
 
+impl From<cdk_common::nut14::Error> for Error {
+    fn from(e: cdk_common::nut14::Error) -> Self {
+        Self::Protocol(e.to_string())
+    }
+}
+
 impl From<cdk::nuts::nut18::Error> for Error {
     fn from(e: cdk::nuts::nut18::Error) -> Self {
         Self::Protocol(e.to_string())

--- a/rust/src/api/payment_request.rs
+++ b/rust/src/api/payment_request.rs
@@ -78,14 +78,28 @@ impl From<CdkPaymentRequest> for PaymentRequest {
             amount: cdk_payment_request.amount.map(|a| a.into()),
             unit: cdk_payment_request.unit.map(|u| u.to_string()),
             single_use: cdk_payment_request.single_use.map(|su| su.into()),
-            mints: cdk_payment_request
-                .mints
-                .map(|m| m.iter().map(|m| m.to_string()).collect()),
+            mints: if cdk_payment_request.mints.is_empty() {
+                None
+            } else {
+                Some(
+                    cdk_payment_request
+                        .mints
+                        .iter()
+                        .map(|m| m.to_string())
+                        .collect(),
+                )
+            },
             description: cdk_payment_request.description,
             transports: if cdk_payment_request.transports.is_empty() {
                 None
             } else {
-                Some(cdk_payment_request.transports.into_iter().map(|t| t.into()).collect())
+                Some(
+                    cdk_payment_request
+                        .transports
+                        .into_iter()
+                        .map(|t| t.into())
+                        .collect(),
+                )
             },
             nut10: cdk_payment_request.nut10.map(|n| n.into()),
         }
@@ -109,9 +123,10 @@ impl TryInto<CdkPaymentRequest> for PaymentRequest {
                 .map(|m| {
                     m.into_iter()
                         .map(|m| m.parse().map_err(|_| Error::InvalidInput))
-                        .collect()
+                        .collect::<Result<Vec<MintUrl>, _>>()
                 })
-                .transpose()?,
+                .transpose()?
+                .unwrap_or_default(),
             description: self.description,
             transports: self
                 .transports
@@ -141,9 +156,10 @@ impl TryInto<CdkPaymentRequest> for &PaymentRequest {
                 .map(|m| {
                     m.iter()
                         .map(|m| m.parse().map_err(|_| Error::InvalidInput))
-                        .collect()
+                        .collect::<Result<Vec<MintUrl>, _>>()
                 })
-                .transpose()?,
+                .transpose()?
+                .unwrap_or_default(),
             description: self.description.clone(),
             transports: self
                 .transports
@@ -167,7 +183,11 @@ impl From<CdkTransport> for Transport {
         Transport {
             _type: cdk_transport._type.into(),
             target: cdk_transport.target,
-            tags: cdk_transport.tags,
+            tags: if cdk_transport.tags.is_empty() {
+                None
+            } else {
+                Some(cdk_transport.tags)
+            },
         }
     }
 }
@@ -177,7 +197,7 @@ impl Into<CdkTransport> for Transport {
         CdkTransport {
             _type: self._type.clone().into(),
             target: self.target,
-            tags: self.tags,
+            tags: self.tags.unwrap_or_default(),
         }
     }
 }
@@ -187,7 +207,7 @@ impl Into<CdkTransport> for &Transport {
         CdkTransport {
             _type: self._type.into(),
             target: self.target.clone(),
-            tags: self.tags.clone(),
+            tags: self.tags.clone().unwrap_or_default(),
         }
     }
 }

--- a/rust/src/api/wallet.rs
+++ b/rust/src/api/wallet.rs
@@ -20,8 +20,8 @@ use cdk_common::{
     nut23::Amountless,
     util::unix_time,
     wallet::{
-        Transaction as CdkTransaction, TransactionDirection as CdkTransactionDirection,
-        TransactionId,
+        KeysetFilter, Transaction as CdkTransaction,
+        TransactionDirection as CdkTransactionDirection, TransactionId,
     },
     MeltOptions as CdkMeltOptions, Mpp, PaymentRequestPayload,
 };
@@ -176,7 +176,7 @@ impl Wallet {
     #[tracing::instrument(skip(self, token))]
     pub async fn is_token_spent(&self, token: Token) -> Result<bool, Error> {
         let token: CdkToken = token.try_into()?;
-        let mint_keysets = self.inner.get_mint_keysets().await?;
+        let mint_keysets = self.inner.get_mint_keysets(KeysetFilter::Active).await?;
         let proof_states = self
             .inner
             .check_proofs_spent(token.proofs(&mint_keysets)?)
@@ -393,7 +393,7 @@ impl Wallet {
         let transports = pay_request.transports.ok_or(Error::InvalidInput)?;
         let transport = transports.first().ok_or(Error::InvalidInput)?;
 
-        let mint_keysets = self.inner.get_mint_keysets().await?;
+        let mint_keysets = self.inner.get_mint_keysets(KeysetFilter::Active).await?;
         let payload = PaymentRequestPayload {
             id: pay_request.payment_id,
             memo,
@@ -517,7 +517,7 @@ impl Wallet {
 
     #[tracing::instrument(skip(self, token))]
     pub async fn reclaim_send(&self, token: Token) -> Result<(), Error> {
-        let mint_keysets = self.inner.get_mint_keysets().await?;
+        let mint_keysets = self.inner.get_mint_keysets(KeysetFilter::Active).await?;
         self.inner
             .sync_proofs_state(token.proofs(&mint_keysets)?)
             .await?;


### PR DESCRIPTION
## What

`master` does not currently build with `cdk 0.16.0`. After `3cd6860 chore: bump cdk 0.16.0`, `cargo build` / `just setup` fails with 10 errors:

- `wallet::get_mint_keysets` now requires a `KeysetFilter` argument (3 call sites)
- `PaymentRequest.mints` changed from `Option<Vec<MintUrl>>` to `Vec<MintUrl>`
- `Transport.tags` changed from `Option<Vec<Vec<String>>>` to `Vec<Vec<String>>`
- `SpendingConditions::new_htlc` returns `Result<_, nut14::Error>`, which has no `From` impl on the plugin's `Error` enum

## Why

Unblocks `cargo build` on master so new contributors can get a green local build, and keeps the plugin aligned with cdk 0.16.

## How

- `rust/src/api/error.rs` — add `impl From<cdk_common::nut14::Error> for Error` routed to `Error::Protocol(...)` (matches the existing `nut11` / `nut18` handling).
- `rust/src/api/wallet.rs` — import `KeysetFilter`, pass `KeysetFilter::Active` at the three call sites (`is_token_spent`, the payment-request send flow, `reclaim_send`). These are all "current wallet operation" contexts, so `Active` is correct; restore paths — which would want `All` — aren't touched.
- `rust/src/api/payment_request.rs` — adapt `From<CdkPaymentRequest>` and both `TryInto<CdkPaymentRequest>` impls, plus the `Transport` <-> `CdkTransport` conversions, to the new `Vec` field shapes.

**The Dart-facing API is intentionally preserved** (`PaymentRequest.mints: List<String>?`, `Transport.tags: List<List<String>>?`). No downstream breakage for existing consumers of `cdk_flutter`.

Generated files (`rust/src/frb_generated.rs`, `lib/src/rust/**`) are intentionally untouched to keep this diff reviewable. Running `just generate` on merge produces a format-only delta (no public-API change).

## Tested

Locally on macOS 26.4 (arm64), Rust 1.95.0, Flutter 3.x, `flutter_rust_bridge_codegen 2.11.1`:

- `cargo build` ✅
- `cargo check` ✅
- `cargo clippy` ✅ (no new warnings)
- `flutter analyze lib` ✅
- `just test macos` against `fake.thesimplekid.dev` — **39 passed, 8 failed**. All 8 failures share the same transient HTTP error (`Error.cdk(field0: Http transport error None: Connection error: error sending request for url (https://fake.thesimplekid.dev/v1/info))`) clustered in the mid-run Multi-Mint and Restore groups; the mint responded `HTTP 200` before and after the run. Most importantly, the test that directly exercises this PR's code path — `Input Parsing › Parse payment request input` — passes.

## Not included

- No `CHANGELOG.md` bump (maintainer owns versioning).
- Pre-existing `cargo fmt` drift in parts of `wallet.rs` not touched by this PR is out of scope.
- Pre-existing `flutter analyze` findings in `cargokit/` and `example/integration_test/simple_test.dart` are out of scope.

Happy to split or reshape however you prefer.